### PR TITLE
fix install deps

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -1,0 +1,6 @@
+from danlp.datasets import DDT
+import os
+from pathlib import Path
+cache_dir = os.path.join(str(Path.home()), '.nerda')
+ner = DDT(cache_dir = cache_dir)
+test = ner.load_as_simple_ner(True)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,13 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    install_requires=['tqdm', 'pyconll', 'tweepy'],
+    install_requires=[
+        'conllu',
+        'pandas'
+        'pyconll', 
+        'tqdm', 
+        'tweepy'
+    ],
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Hi

Thanks for the package! 

After I installed the package, it broke down, when I did:

```
from danlp.datasets import DDT
ddt = DDT()
ddt_ne = ddt.load_as_simple_ner(predefined_splits= True)
```

As far as I can see, this is due to the fact, 'pandas' and 'conllu' are both used in the code but NOT included as install requirements in setup.py. 

I suggest, you include both.

I understand, why you do not include stuff like 'torch', 'flair' and so on to keep the package lightweight, but I think the above dependencies should.





