### PR TITLE
Fix #156 with load_with_pandas example error

### DIFF
--- a/docs/docs/datasets.md
+++ b/docs/docs/datasets.md
@@ -369,7 +369,7 @@ The dataset can be loaded with the DaNLP package:
 ```python
 from danlp.datasets import DaWikiNED
 dawikined = DaWikiNED()
-train, dev, test = dawikined.load_with_pandas()
+train = dawikined.load_with_pandas()
 ```
 
 To get the KG context (Wikidata properties and description) of a QID (from the DaWikiNED database), you can use:


### PR DESCRIPTION
`load_with_pandas` function example now only sets the train dataframe.

## Description
Fix code in documentation for dawikined

## Types of change
<!-- Check the type of change that corresponds to your PR -->

- [] bug fix
- [] add a tutorial 
- [] benchmark of a non-DaNLP tool/model
- [] add a model
- [] add a dataset
- [x] other : documentation fix

## Checklist
<!--- Check the boxes that apply to your type of PR if your PR fulfills the criteria
and delete the lines corresponding to the other type of changes -->

Bug fix
- [x] add issue number (if it exists) #156

Tutorial
- [] focus on industry-friendly Danish NLP
- [] update the `examples/tutorials/README.md`

Benchmark
- [] add required packages in requirements_benchmarks.txt
- [] benchmark on the same data and tokenization as other models
- [] update the documentation with the results from benchmarking

Model/Data
- [] add unit test (required)
- [] add benchmark evaluation (optional)
- [] add documention (optional)
